### PR TITLE
Event creation by user

### DIFF
--- a/components/EventItem.js
+++ b/components/EventItem.js
@@ -24,7 +24,6 @@ const EventItem = ({ item, imgDisplay, fullNameDisplay }) => {
   }
 
   const {
-    loveStyleTag,
     dateDate,
     dateTime,
     pickRestaurantValue,
@@ -39,11 +38,6 @@ const EventItem = ({ item, imgDisplay, fullNameDisplay }) => {
         <Text style={styles.eventCard__heading}>
           {datePlace !== '' ? datePlace : pickRestaurantValue}
         </Text>
-        {loveStyleTag.map((tag, index) => (
-          <Text style={styles.eventCard__tag} key={index}>
-            {tag}
-          </Text>
-        ))}
       </View>
       <Text style={styles.eventCard__dateTime}>
         {new Date(dateDate).toLocaleDateString()} @ {dateTime}

--- a/components/EventItemHistory.js
+++ b/components/EventItemHistory.js
@@ -13,17 +13,17 @@ const EventItemHistory = ({ item, imgDisplay, fullNameDisplay }) => {
     })
   }
 
-  const { id, eventName, loveStyleTag, dateDate, dateRating, state } = item
+  const { id, eventName, dateDate, dateRating, state } = item
 
   return (
     <View style={styles.eventCard}>
       <View style={styles.eventCard__top}>
         <Text style={styles.eventCard__heading}>{eventName}</Text>
-        {loveStyleTag?.map((tag, index) => (
-          <Text style={styles.eventCard__tag} key={index}>
-            {tag}
-          </Text>
-        ))}
+
+        <Text style={styles.eventCard__tag}>
+          {state?.charAt(0).toUpperCase()}
+          {state?.slice(1)}
+        </Text>
       </View>
 
       <Text style={styles.eventCard__dateTime}>
@@ -47,10 +47,11 @@ const EventItemHistory = ({ item, imgDisplay, fullNameDisplay }) => {
 
         {auth.currentUser.uid === 'KgJLUBI6d9QIpR0tnGKPERyF0S03' ||
         auth.currentUser.uid === 'LkdoS9fnSDNwhH22mfrmzh7DLG83' ? (
-          <Pressable onPress={() => console.log()} style={styles.button}>
-            <Text style={{ color: 'white', fontWeight: 'bold' }}>
-              Edit Event
-            </Text>
+          <Pressable
+            onPress={() => console.log()}
+            style={styles.eventCard__link}
+          >
+            <Text>Edit Event</Text>
           </Pressable>
         ) : (
           ''

--- a/components/RelationshipItem.js
+++ b/components/RelationshipItem.js
@@ -18,6 +18,7 @@ const RelationshipItem = ({
   upcomingEvents,
   imgDisplay,
   fullNameDisplay,
+  userId,
 }) => {
   const navigation = useNavigation()
 
@@ -52,6 +53,7 @@ const RelationshipItem = ({
               nativeID={item?.id}
             />
           )}
+
           <Pressable onPress={(e) => handlePress(e.target.id)}>
             <Text style={styles.relationshipCard__name} nativeID={item?.id}>
               {item?.name} {item?.lastName}

--- a/screens/AddRelationshipScreen.js
+++ b/screens/AddRelationshipScreen.js
@@ -83,12 +83,11 @@ const AddRelationship = () => {
   const handlePress = async () => {
     if (name && lastName && birthday) {
       setLoading(true)
-      setDoc(doc(db, 'prevEvents', prevID), {
+      setDoc(doc(db, 'events', prevID), {
         name: name,
         lastName: lastName,
         fullName: `${name} ${lastName}`,
         img: profileImage,
-        loveStyleTag: [],
         datePlace,
         eventName,
         dateDate,

--- a/screens/AdminRelationshipsView.js
+++ b/screens/AdminRelationshipsView.js
@@ -51,7 +51,7 @@ const AdminRelationshipsView = () => {
               <Text style={[styles.h4, styles.medGap]}>Relationships</Text>
               {relationships.length !== 0 ? (
                 relationships.map((item) => (
-                  <RelationshipItem item={item} key={item.id} />
+                  <RelationshipItem item={item} key={item.id} userId={itemId} />
                 ))
               ) : (
                 <Text style={styles.p}>
@@ -61,7 +61,10 @@ const AdminRelationshipsView = () => {
             </View>
             <View style={[styles.page__lower, styles.center]}>
               <Pressable style={[styles.button, styles.buttonGrey]}>
-                <Text style={[styles.button__text, styles.buttonGrey__text]} onPress={handlePress}>
+                <Text
+                  style={[styles.button__text, styles.buttonGrey__text]}
+                  onPress={handlePress}
+                >
                   BACK
                 </Text>
               </Pressable>

--- a/screens/EditEventScreen.js
+++ b/screens/EditEventScreen.js
@@ -13,17 +13,6 @@ import DatePicker from '../components/form/DatePicker'
 
 const EditEventScreen = () => {
   const [isLoading, setIsLoading] = useState(true)
-  const [openLoveStyleTag, setOpenLoveStyleTag] = useState(false)
-  const [editLoveStyleTag, setEditLoveStyleTag] = useState(null)
-  const [loveStyleTagItems, setLoveStyleTagItems] = useState([
-    { label: 'Activity', value: 'Activity' },
-    { label: 'Financial', value: 'Financial' },
-    { label: 'Physical', value: 'Physical' },
-    { label: 'Appreciation', value: 'Appreciation' },
-    { label: 'Emotional', value: 'Emotional' },
-    { label: 'Intellectual', value: 'Intellectual' },
-    { label: 'Practical', value: 'Practical' },
-  ])
   const [editEventName, setEditEventName] = useState('')
   const [editDate, setEditDate] = useState('')
   const [editTime, setEditTime] = useState('')
@@ -31,8 +20,8 @@ const EditEventScreen = () => {
   const [editComments, setEditComments] = useState('')
   const [showDatePicker, setShowDatePicker] = useState(false)
   const [showTimePicker, setShowTimePicker] = useState(false)
-  const [showLoveStyles, setShowLoveStyles] = useState(false)
   const [singleRelationship, setSingleRelationship] = useState('')
+  const [eventState, setEventState] = useState('')
   const navigation = useNavigation()
   const route = useRoute()
   const { item, imgDisplay, fullNameDisplay } = route.params
@@ -45,7 +34,6 @@ const EditEventScreen = () => {
 
   const {
     eventName,
-    loveStyleTag,
     dateDate,
     datePlace,
     dateTime,
@@ -82,17 +70,15 @@ const EditEventScreen = () => {
     setEditTime(dateTime)
     setEditPlace(datePlace)
     setEditComments(additionalComments)
-    setEditLoveStyleTag(loveStyleTag)
   }, [
     dateDate,
     dateTime,
     datePlace,
     additionalComments,
     eventName,
-    loveStyleTag,
   ])
 
-  const docRef = doc(db, 'upcomingEvents', id)
+  const docRef = doc(db, 'events', id)
 
   useEffect(() => {
     getSpecificDoc()
@@ -113,17 +99,28 @@ const EditEventScreen = () => {
     }
   }
 
+  useEffect(() => {
+    const today = Date.parse(new Date())
+    const event = Date.parse(new Date(editDate))
+
+    if (today > event) {
+      setEventState(true)
+    } else {
+      setEventState(false)
+    }
+  }, [editDate])
+
   const handleSave = async () => {
     if (singleRelationship) {
       await updateDoc(
         docRef,
         {
           eventName: editEventName ? editEventName : eventName,
-          loveStyleTag: editLoveStyleTag ? editLoveStyleTag : loveStyleTag,
           additionalComments: editComments ? editComments : additionalComments,
           dateDate: editDate ? editDate : dateDate,
           datePlace: editPlace ? editPlace : datePlace,
           dateTime: editTime ? editTime : dateTime,
+          state: editDate ? (eventState ? 'past' : 'upcoming') : item?.state,
         },
         { merge: true }
       )
@@ -135,8 +132,9 @@ const EditEventScreen = () => {
           })
         })
         .then(() =>
-          auth.currentUser.uid !== 'KgJLUBI6d9QIpR0tnGKPERyF0S03' ||
-          auth.currentUser.uid !== 'LkdoS9fnSDNwhH22mfrmzh7DLG83'
+          // auth.currentUser.uid !== 'KgJLUBI6d9QIpR0tnGKPERyF0S03' ||
+          // auth.currentUser.uid !== 'LkdoS9fnSDNwhH22mfrmzh7DLG83'
+          auth.currentUser.uid !== 'KgJLUBI6d9QIpR0tnGKPERyF0S03'
             ? navigation.navigate('Relationships')
             : navigation.navigate('Admin')
         )
@@ -160,60 +158,6 @@ const EditEventScreen = () => {
                 />
                 <Text>{fullNameDisplay}</Text>
               </View> */}
-              <Text style={[styles.h5, { marginBottom: 16 }]}>
-                LOVE STYLE TAGS
-              </Text>
-              {showLoveStyles ? (
-                <View style={styles.form__twoCol}>
-                  <DropDownPicker
-                    open={openLoveStyleTag}
-                    value={editLoveStyleTag}
-                    items={loveStyleTagItems}
-                    setOpen={setOpenLoveStyleTag}
-                    setValue={setEditLoveStyleTag}
-                    setItems={setLoveStyleTagItems}
-                    style={styles.form__select}
-                    placeholder="Select Love Styles"
-                    placeholderStyle={{ color: 'rgba(51,55,75,0.5)' }}
-                    dropDownContainerStyle={{
-                      margin: 'auto',
-                      color: '#33374B',
-                      zIndex: '20000',
-                      height: 160,
-                      bottom: -135,
-                      borderColor: 'rgba(199, 203, 217, 1)',
-                      paddingLeft: 4,
-                      fontSize: 17,
-                    }}
-                    listItemLabelStyle={{
-                      color: '#33374B',
-                    }}
-                    disabledItemLabelStyle={{
-                      color: 'rgba(51,55,75,0.5)',
-                    }}
-                    labelStyle={{
-                      color: '#33374B',
-                    }}
-                    multiple={true}
-                    mode="BADGE"
-                    badgeDotColors={['#586187']}
-                  />
-                  <Pressable onPress={() => setShowLoveStyles(false)}>
-                    <Image
-                      source={CloseIcon}
-                      style={{ width: 24, height: 24 }}
-                    />
-                  </Pressable>
-                </View>
-              ) : (
-                <Pressable onPress={() => setShowLoveStyles(true)}>
-                  {loveStyleTag.map((item, index) => (
-                    <Text style={styles.loveStyleTags__tag} key={index}>
-                      {item}
-                    </Text>
-                  ))}
-                </Pressable>
-              )}
 
               <Text style={[styles.form__label, { marginTop: 16 }]}>
                 Event Name

--- a/screens/EventDetails.js
+++ b/screens/EventDetails.js
@@ -19,7 +19,7 @@ const EventDetails = () => {
           auth.currentUser.uid !== 'LkdoS9fnSDNwhH22mfrmzh7DLG83' ? (
             <Pressable
               onPress={() =>
-                navigation.navigate('Event History', {
+                navigation.navigate('Relationships', {
                   item,
                   imgDisplay,
                   fullNameDisplay,
@@ -41,15 +41,6 @@ const EventDetails = () => {
           )}
           <View style={styles.eventHeading}>
             <Text style={[styles.h2, styles.alignLeft]}>{item?.eventName}</Text>
-            <View
-              style={[styles.loveStyleTags, { justifyContent: 'flex-end' }]}
-            >
-              {item?.loveStyleTag.map((i, index) => (
-                <Text style={styles.loveStyleTags__tag} key={index}>
-                  {i}
-                </Text>
-              ))}
-            </View>
           </View>
           <View style={styles.eventRelGraphic}>
             <Text>With</Text>

--- a/screens/EventRatingScreen.js
+++ b/screens/EventRatingScreen.js
@@ -28,14 +28,14 @@ const EventRatingScreen = () => {
     }).start()
   }, [fadeAnim])
 
-  const { id, relID, name, loveStyleTag, eventName, dateDate, dateTime } = item
+  const { id, relID, name, eventName, dateDate, dateTime } = item
 
-  const upcomingEventsRef = doc(db, 'prevEvents', id)
+  const eventsRef = doc(db, 'events', id)
   const relRef = doc(db, 'relationships', relID)
 
   const handleSave = async () => {
     await updateDoc(
-      upcomingEventsRef,
+      eventsRef,
       {
         dateRating,
         highlight,
@@ -72,13 +72,6 @@ const EventRatingScreen = () => {
               <Text style={styles.eventSummary__title}>
                 {eventName} with {name}
               </Text>
-              <View style={styles.eventTags}>
-                {loveStyleTag?.map((tag, index) => (
-                  <Text style={styles.eventTags__tag} key={index}>
-                    {tag}
-                  </Text>
-                ))}
-              </View>
               <Text style={styles.eventSummary__date}>
                 {new Date(dateDate).toLocaleDateString()} @ {dateTime}
               </Text>

--- a/screens/RelationshipScreen.js
+++ b/screens/RelationshipScreen.js
@@ -16,7 +16,7 @@ import OtherDetails from '../components/OtherDetails'
 import Avatar from '../assets/avatar.png'
 import useAuth from '../hooks/useAuth'
 import axios from 'axios'
-import {TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN} from '@env'
+import { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } from '@env'
 
 const Relationship = () => {
   const [singleRelationship, setSingleRelationship] = useState('')
@@ -99,55 +99,10 @@ const Relationship = () => {
     })
   }
 
-  const handleMessagePress = async () =>  {
-    if (
-      auth.currentUser.uid === 'KgJLUBI6d9QIpR0tnGKPERyF0S03' ||
-      auth.currentUser.uid === 'LkdoS9fnSDNwhH22mfrmzh7DLG83'
-    ) {
-      navigation.navigate('Schedule Event', {
-        itemId,
-      })
-    } else {
-      setShowMessage(true)
-
-      const sid = TWILIO_ACCOUNT_SID;
-      const token = TWILIO_AUTH_TOKEN;
-
-      const qs = require('qs');
-      const cyranoText = `${userData?.name} ${userData?.lastName} has requested an event with ${singleRelationship?.name} ${singleRelationship?.lastName}. Text them back at ${userData?.phone}`;
-
-      await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
-        Body: cyranoText,
-        From: '+19705008871',
-        To: '+12543544848'
-      }),
-      {
-        auth: {
-          username: sid,
-          password: token
-        }
-      }));
-
-      const userText = `A message has been sent to your Cyrano. They will be in touch soon with a recommendation about your event with ${singleRelationship?.name} ${singleRelationship?.lastName}.`
-      await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
-        Body: userText,
-        From: '+19705008871',
-        To: userData?.phone
-      }),
-      {
-        auth: {
-          username: sid,
-          password: token
-        }
-      }));
-
-      console.log('Name: ', singleRelationship?.name)
-      console.log('Last Name: ', singleRelationship?.lastName)
-      console.log('User Phone: ', userData?.phone)
-      console.log('User name: ', userData?.name)
-      console.log('User Last Name: ', userData?.lastName)
-      console.log('User Full Name: ', userData?.fullName)
-    }
+  const handleMessagePress = async () => {
+    navigation.navigate('Schedule Event', {
+      itemId,
+    })
   }
 
   return (
@@ -221,6 +176,9 @@ const Relationship = () => {
                         id,
                         rating: relationshipRating,
                         comments: ratingComments ? ratingComments : 'N/A',
+                        upcomingEvents,
+                        imgDisplay,
+                        fullNameDisplay
                       })
                     }
                   >
@@ -272,7 +230,9 @@ const Relationship = () => {
             <Pressable
               onPress={() =>
                 navigation.navigate('Event History', {
-                  itemId,
+                  itemId: singleRelationship?.author.id,
+                  imgDisplay,
+                  fullNameDisplay
                 })
               }
             >

--- a/screens/RelationshipStatusScreen.js
+++ b/screens/RelationshipStatusScreen.js
@@ -11,7 +11,8 @@ import Back from '../assets/arrow-back.svg'
 const RelationshipStatusScreen = () => {
   const route = useRoute()
   const navigation = useNavigation()
-  const { rating, comments, id } = route.params
+  const { rating, comments, id, upcomingEvents, imgDisplay, fullNameDisplay } =
+    route.params
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -31,7 +32,10 @@ const RelationshipStatusScreen = () => {
               <Pressable
                 onPress={() =>
                   navigation.navigate('Relationship', {
-                    id
+                    id,
+                    upcomingEvents,
+                    imgDisplay,
+                    fullNameDisplay,
                   })
                 }
               >

--- a/screens/RelationshipsHomeAdminScreen.js
+++ b/screens/RelationshipsHomeAdminScreen.js
@@ -19,8 +19,9 @@ const RelationshipsHomeAdminScreen = () => {
   const [imgDisplay, setImgDisplay] = useState('')
   const [fullNameDisplay, setFullNameDisplay] = useState('')
   const [id, setId] = useState('')
+  const [authorId, setAuthorId] = useState('')
   const relationshipRef = collection(db, 'relationships')
-  const upcomingEventsRef = collection(db, 'upcomingEvents')
+  const upcomingEventsRef = collection(db, 'events')
   const route = useRoute()
   const { itemId } = route.params
 
@@ -34,8 +35,9 @@ const RelationshipsHomeAdminScreen = () => {
   const getUpcomingEvents = async () => {
     const data = await getDocs(upcomingEventsRef)
     const newData = data.docs.map((doc) => doc.data())
+    const filterUpcoming = newData.filter((item) => item.state === 'upcoming')
 
-    setUpcomingArr(newData)
+    setUpcomingArr(filterUpcoming)
   }
 
   useEffect(() => {
@@ -53,6 +55,7 @@ const RelationshipsHomeAdminScreen = () => {
     if (relationships && upcomingArr) {
       relationships.map((item) => {
         setId(item?.id)
+        setAuthorId(item?.author.id)
         setImgDisplay(item?.profileImage)
         setFullNameDisplay(`${item?.name} ${item?.lastName}`)
         const newArr = upcomingArr.filter((i) => i.relID === item.id)
@@ -136,7 +139,7 @@ const RelationshipsHomeAdminScreen = () => {
                     <Pressable
                       onPress={() =>
                         navigation.navigate('Event History', {
-                          itemId: 'ifgjdoigjsdo',
+                          itemId: authorId,
                           imgDisplay,
                           fullNameDisplay,
                         })
@@ -157,6 +160,7 @@ const RelationshipsHomeAdminScreen = () => {
                             upcomingEvents={upcomingEvents}
                             imgDisplay={imgDisplay}
                             fullNameDisplay={fullNameDisplay}
+                            userId={itemId}
                           />
                         </View>
                       ))}

--- a/screens/RelationshipsHomeScreen.js
+++ b/screens/RelationshipsHomeScreen.js
@@ -11,7 +11,7 @@ import EventItem from '../components/EventItem'
 import Page from '../shared/Page'
 import useAuth from '../hooks/useAuth'
 import axios from 'axios'
-import {TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN} from '@env'
+import { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } from '@env'
 
 const RelationshipsHomeScreen = () => {
   const [loading, setLoading] = useState(true)
@@ -23,7 +23,7 @@ const RelationshipsHomeScreen = () => {
   const [upcomingEvents, setUpcomingEvents] = useState([])
   const [showMessage, setShowMessage] = useState(false)
   const relationshipRef = collection(db, 'relationships')
-  const upcomingEventsRef = collection(db, 'upcomingEvents')
+  const upcomingEventsRef = collection(db, 'events')
   const isFocused = useIsFocused()
   const { userData, getUser } = useAuth()
 
@@ -43,8 +43,9 @@ const RelationshipsHomeScreen = () => {
   const getUpcomingEvents = async () => {
     const data = await getDocs(upcomingEventsRef)
     const newData = data.docs.map((doc) => doc.data())
+    const filterUpcoming = newData.filter((item) => item.state === 'upcoming')
 
-    setUpcomingArr(newData)
+    setUpcomingArr(filterUpcoming)
   }
 
   useEffect(() => {
@@ -86,38 +87,37 @@ const RelationshipsHomeScreen = () => {
   }, [auth])
 
   const handleMessagePress = async () => {
-    setShowMessage(true);
-
-    const sid = TWILIO_ACCOUNT_SID;
-    const token = TWILIO_AUTH_TOKEN;
-
-    const qs = require('qs');
-    const cyranoText = `${userData?.name} ${userData?.lastName} has requested an event with ${relationships[0].name} ${relationships[0].lastName}. Text them back at ${userData?.phone}`;
-
-    await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
-      Body: cyranoText,
-      From: '+19705008871',
-      To: '+12543544848'
-    }),
-    {
-      auth: {
-        username: sid,
-        password: token
-      }
-    }));
-
-    const userText = `A message has been sent to your Cyrano. They will be in touch soon with a recommendation about your event with ${relationships[0].name} ${relationships[0].lastName}.`
-    await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
-      Body: userText,
-      From: '+19705008871',
-      To: userData?.phone
-    }),
-    {
-      auth: {
-        username: sid,
-        password: token
-      }
-    }));
+    navigation.navigate('Schedule Event', {
+      itemId: relationships[0].id,
+    })
+    // setShowMessage(true);
+    // const sid = TWILIO_ACCOUNT_SID;
+    // const token = TWILIO_AUTH_TOKEN;
+    // const qs = require('qs');
+    // const cyranoText = `${userData?.name} ${userData?.lastName} has requested an event with ${relationships[0].name} ${relationships[0].lastName}. Text them back at ${userData?.phone}`;
+    // await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
+    //   Body: cyranoText,
+    //   From: '+19705008871',
+    //   To: '+12543544848'
+    // }),
+    // {
+    //   auth: {
+    //     username: sid,
+    //     password: token
+    //   }
+    // }));
+    // const userText = `A message has been sent to your Cyrano. They will be in touch soon with a recommendation about your event with ${relationships[0].name} ${relationships[0].lastName}.`
+    // await(axios.post("https://api.twilio.com/2010-04-01/Accounts/" + sid + "/Messages.json", qs.stringify({
+    //   Body: userText,
+    //   From: '+19705008871',
+    //   To: userData?.phone
+    // }),
+    // {
+    //   auth: {
+    //     username: sid,
+    //     password: token
+    //   }
+    // }));
   }
 
   return (
@@ -168,22 +168,21 @@ const RelationshipsHomeScreen = () => {
                           ]}
                           onPress={handleMessagePress}
                         >
-                          {showMessage ? (
+                          {/* {showMessage ? (
                             <Text>
                               A message has been sent. A cyrano will contact you
                               soon
                             </Text>
-                          ) : (
-                            <Text
-                              style={[
-                                styles.button__text,
-                                styles.buttonGrey__text,
-                                styles.superBold,
-                              ]}
-                            >
-                              SCHEDULE AN EVENT
-                            </Text>
-                          )}
+                          ) : ( */}
+                          <Text
+                            style={[
+                              styles.button__text,
+                              styles.buttonGrey__text,
+                              styles.superBold,
+                            ]}
+                          >
+                            SCHEDULE AN EVENT
+                          </Text>
                         </Pressable>
                       </View>
                     ) : (
@@ -199,7 +198,7 @@ const RelationshipsHomeScreen = () => {
                     <Pressable
                       onPress={() =>
                         navigation.navigate('Event History', {
-                          itemId: 'ifgjdoigjsdo',
+                          itemId: relationships[0].author.id,
                           imgDisplay,
                           fullNameDisplay,
                         })

--- a/screens/ScheduleEvent.js
+++ b/screens/ScheduleEvent.js
@@ -4,7 +4,7 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import { styles } from '../styles'
 import DropDownPicker from 'react-native-dropdown-picker'
 import Page from '../shared/Page'
-import { db } from '../config/firebase-config'
+import { db, auth } from '../config/firebase-config'
 import { doc, getDoc, setDoc } from 'firebase/firestore'
 import Toast from 'react-native-toast-message'
 import uuid from 'react-native-uuid'
@@ -19,17 +19,7 @@ const ScheduleEvent = () => {
   const [docID, setDocID] = useState('')
   const [allID, setAllID] = useState('')
   const [additionalComments, setAdditionalComments] = useState('')
-  const [openLoveStyleTag, setOpenLoveStyleTag] = useState(false)
-  const [loveStyleTagValue, setLoveStyleTagValue] = useState(null)
-  const [loveStyleTagItems, setLoveStyleTagItems] = useState([
-    { label: 'Activity', value: 'Activity' },
-    { label: 'Financial', value: 'Financial' },
-    { label: 'Physical', value: 'Physical' },
-    { label: 'Appreciation', value: 'Appreciation' },
-    { label: 'Emotional', value: 'Emotional' },
-    { label: 'Intellectual', value: 'Intellectual' },
-    { label: 'Practical', value: 'Practical' },
-  ])
+  const [eventState, setEventState] = useState('')
   const [isDisabled, setIsDisabled] = useState(true)
   const navigation = useNavigation()
   const route = useRoute()
@@ -65,14 +55,24 @@ const ScheduleEvent = () => {
     setAllID(uuid.v4())
   }, [])
 
+  useEffect(() => {
+    const today = Date.parse(new Date())
+    const event = Date.parse(new Date(dateDate))
+
+    if (today > event) {
+      setEventState(true)
+    } else {
+      setEventState(false)
+    }
+  }, [dateDate])
+
   const handlePress = async () => {
-    await setDoc(doc(db, 'upcomingEvents', docID), {
+    await setDoc(doc(db, 'events', docID), {
       id: docID,
       name: relationshipData.name,
       lastName: relationshipData.lastName,
       fullName: `${relationshipData.name} ${relationshipData.lastName}`,
       img: relationshipData.profileImage,
-      loveStyleTag: loveStyleTagValue,
       eventName,
       datePlace,
       dateDate,
@@ -80,9 +80,14 @@ const ScheduleEvent = () => {
       dateRating: '',
       additionalComments,
       relID: itemId,
-      state: 'upcoming',
+      state: eventState ? 'past' : 'upcoming',
     })
-      .then(navigation.navigate('Admin'))
+      .then(
+        auth.currentUser.uid === 'KgJLUBI6d9QIpR0tnGKPERyF0S03' ||
+          auth.currentUser.uid === 'LkdoS9fnSDNwhH22mfrmzh7DLG83'
+          ? navigation.navigate('Admin')
+          : navigation.navigate('Relationships')
+      )
       .then(
         Toast.show({
           type: 'success',
@@ -165,40 +170,6 @@ const ScheduleEvent = () => {
               onChangeText={(newNextDatePlace) =>
                 setNextDatePlace(newNextDatePlace)
               }
-            />
-            <Text style={styles.form__label}>Select the love styles</Text>
-            <DropDownPicker
-              open={openLoveStyleTag}
-              value={loveStyleTagValue}
-              items={loveStyleTagItems}
-              setOpen={setOpenLoveStyleTag}
-              setValue={setLoveStyleTagValue}
-              setItems={setLoveStyleTagItems}
-              style={styles.form__select}
-              placeholder="Select Love Styles"
-              placeholderStyle={{ color: 'rgba(51,55,75,0.5)' }}
-              dropDownContainerStyle={{
-                margin: 'auto',
-                color: '#33374B',
-                zIndex: '20000',
-                height: 160,
-                bottom: -135,
-                borderColor: 'rgba(199, 203, 217, 1)',
-                paddingLeft: 4,
-                fontSize: 17,
-              }}
-              listItemLabelStyle={{
-                color: '#33374B',
-              }}
-              disabledItemLabelStyle={{
-                color: 'rgba(51,55,75,0.5)',
-              }}
-              labelStyle={{
-                color: '#33374B',
-              }}
-              multiple={true}
-              mode="BADGE"
-              badgeDotColors={['#586187']}
             />
             <View style={{ zIndex: 1 }}>
               <Text style={styles.form__label}>Additional Comments</Text>


### PR DESCRIPTION
This PR Solves this issues/tasks:

- Users are able to create events.
- It adds a logic to check if the event has passed or not, and adds a `state` depending on the date of the event.
- Removes "Love Style Tag" from the entire app.
- Removes filter event by "Love style".
- Removes 'upcomingEvents' and 'prevEvents' and creates a new 'events' collections with different states.
- It also fixes some bugs and some other stuff attached to the above items.

Notes:

- All events and relationships has been removed from Firebase.

To Test:

- Get this branch 
- Log in and create a new relationship.
- Then navigate to "Events History" and check if the past event is there.
- Press "Schedule an event" and create a new event. It can be past or upcoming. If it's past you should see it in events history, if it's upcoming, you should see it in upcoming events and also in the events history.
- Test every feature in the app
- Create an upcoming event and then edit it and put a past date, it should change to `state: past` and not shown in upcoming but with a `past` badge in the events history.
- Login as Admin and create an event for an user. You should see everything working right.
- All redirections, next and back buttons should go where it should, both admin and regular user.